### PR TITLE
[BE] 소비 확률 수치 조정

### DIFF
--- a/generator-core/src/main/java/com/simpaylog/generatorcore/service/AccountService.java
+++ b/generator-core/src/main/java/com/simpaylog/generatorcore/service/AccountService.java
@@ -54,11 +54,6 @@ public class AccountService {
         return false;
     }
 
-    public BigDecimal getBalance(Long userId) {
-        Account checking = getAccountByType(userId, AccountType.CHECKING);
-        return checking.getBalance();
-    }
-
     public void deposit(Long userId, BigDecimal amount, LocalDateTime dateTime) {
         if (amount == null || amount.signum() < 0) {
             throw new CoreException("금액이 잘못되었습니다.");

--- a/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/cache/DecileStatsLocalCache.java
+++ b/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/cache/DecileStatsLocalCache.java
@@ -1,0 +1,51 @@
+package com.simpaylog.generatorsimulator.cache;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.simpaylog.generatorsimulator.cache.dto.DecileStat;
+import com.simpaylog.generatorsimulator.dto.CategorySpendingWeight;
+import com.simpaylog.generatorsimulator.dto.CategoryType;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Getter
+@Component
+public class DecileStatsLocalCache {
+    private final Map<Integer, Map<CategoryType, BigDecimal>> cache = new ConcurrentHashMap<>();
+
+    public Map<CategoryType, BigDecimal> getDecileStat(int decile) {
+        Map<CategoryType, BigDecimal> env = cache.get(decile);
+        if (env == null) throw new IllegalArgumentException("No stats for decile=" + decile);
+        return new EnumMap<>(env); // 복사본
+    }
+
+    @PostConstruct
+    public void init() {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            InputStream input = new ClassPathResource("stats.json").getInputStream();
+            TypeReference<List<DecileStat>> typeRef = new TypeReference<>() {};
+            List<DecileStat> decileStats = mapper.readValue(input, typeRef);
+            for(DecileStat stat : decileStats) {
+                Map<CategoryType, BigDecimal> env = new EnumMap<>(CategoryType.class);
+                stat.byCategory().forEach((k, v) -> env.put(CategoryType.fromKey(k), v));
+                cache.put(stat.decile(), env);
+            }
+            log.info("[DecileStatsLocalCache] 캐시 로딩 완료: 10개 중 {}개", cache.size());
+        } catch (Exception e) {
+            log.error("캐시 초기화 중 오류 발생: {}", e.getMessage());
+        }
+    }
+}

--- a/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/cache/DecileStatsLocalCache.java
+++ b/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/cache/DecileStatsLocalCache.java
@@ -2,9 +2,8 @@ package com.simpaylog.generatorsimulator.cache;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.simpaylog.generatorcore.dto.CategoryType;
 import com.simpaylog.generatorsimulator.cache.dto.DecileStat;
-import com.simpaylog.generatorsimulator.dto.CategorySpendingWeight;
-import com.simpaylog.generatorsimulator.dto.CategoryType;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +12,6 @@ import org.springframework.stereotype.Component;
 
 import java.io.InputStream;
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -36,9 +34,10 @@ public class DecileStatsLocalCache {
         try {
             ObjectMapper mapper = new ObjectMapper();
             InputStream input = new ClassPathResource("stats.json").getInputStream();
-            TypeReference<List<DecileStat>> typeRef = new TypeReference<>() {};
+            TypeReference<List<DecileStat>> typeRef = new TypeReference<>() {
+            };
             List<DecileStat> decileStats = mapper.readValue(input, typeRef);
-            for(DecileStat stat : decileStats) {
+            for (DecileStat stat : decileStats) {
                 Map<CategoryType, BigDecimal> env = new EnumMap<>(CategoryType.class);
                 stat.byCategory().forEach((k, v) -> env.put(CategoryType.fromKey(k), v));
                 cache.put(stat.decile(), env);

--- a/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/cache/dto/DecileStat.java
+++ b/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/cache/dto/DecileStat.java
@@ -1,0 +1,10 @@
+package com.simpaylog.generatorsimulator.cache.dto;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public record DecileStat(
+        int decile,
+        Map<String, BigDecimal> byCategory
+) {
+}

--- a/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/service/SimpleEnvelopeScaler.java
+++ b/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/service/SimpleEnvelopeScaler.java
@@ -1,0 +1,78 @@
+package com.simpaylog.generatorsimulator.service;
+
+import com.simpaylog.generatorsimulator.utils.MoneyUtil;
+import com.simpaylog.generatorsimulator.dto.CategoryType;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.EnumMap;
+import java.util.Map;
+
+public final class SimpleEnvelopeScaler {
+    private final EnumMap<CategoryType, BigDecimal> remainingBudget;
+    private final EnumMap<CategoryType, Integer> remainingEvents;
+
+    private final double lamdaMin;
+    private final double lamdaMax;
+
+    public SimpleEnvelopeScaler(Map<CategoryType, BigDecimal> envelope, Map<CategoryType, Integer> approxCounts) {
+        this(envelope, approxCounts, 0.65, 1.75);
+    }
+
+    public SimpleEnvelopeScaler(Map<CategoryType, BigDecimal> budget, Map<CategoryType, Integer> events, double lamdaMin, double lamdaMax) {
+        this.remainingBudget = new EnumMap<>(CategoryType.class);
+        this.remainingEvents = new EnumMap<>(CategoryType.class);
+        this.lamdaMin = lamdaMin;
+        this.lamdaMax = lamdaMax;
+
+        this.remainingBudget.putAll(budget);
+        for(Map.Entry<CategoryType, Integer> entry : events.entrySet()) {
+            this.remainingEvents.put(entry.getKey(), Math.max(1, entry.getValue()));
+        }
+    }
+
+    public BigDecimal scale(CategoryType category, BigDecimal sampleAmount) {
+        if(sampleAmount == null || sampleAmount.signum() <= 0) {
+            return BigDecimal.ZERO;
+        }
+
+        BigDecimal remainingAmount = remainingBudget.getOrDefault(category, BigDecimal.ZERO); // 남은 예산
+        int remainCnt = Math.max(1, remainingEvents.getOrDefault(category, 1));
+
+        if(remainingAmount.signum() <= 0) { // 남은 예산이 0원인 경우
+            remainingEvents.put(category, Math.max(0, remainCnt - 1));
+            return BigDecimal.ZERO;
+        }
+        // 목표 금액(샘플 금액이 목표보다 크면 금액을 줄이고, 작으면 금액을 늘림)
+        BigDecimal targetAmount = remainingAmount.divide(BigDecimal.valueOf(remainCnt), 8, RoundingMode.HALF_UP);
+        BigDecimal lambdaBD = targetAmount.divide(sampleAmount, 8, RoundingMode.HALF_UP);
+        double lambda = clamp(lambdaBD.doubleValue(), lamdaMin, lamdaMax);
+
+        // 최종 금액
+        BigDecimal cost = sampleAmount.multiply(BigDecimal.valueOf(lambda)).setScale(0, RoundingMode.HALF_UP);
+        BigDecimal finalAmount = MoneyUtil.roundTo10(cost);
+        BigDecimal nextAmount = remainingAmount.subtract(finalAmount);
+        if(nextAmount.signum() < 0) nextAmount = BigDecimal.ZERO;
+        remainingBudget.put(category, nextAmount);
+        remainingEvents.put(category, Math.max(0, remainCnt - 1));
+
+        return finalAmount;
+    }
+
+    public void rollback(CategoryType category, BigDecimal committedFinalAmount) {
+        remainingBudget.merge(category, committedFinalAmount, BigDecimal::add);
+        remainingEvents.merge(category, 1, Integer::sum);
+    }
+
+    public BigDecimal getRemainingBudget(CategoryType category) {
+        return remainingBudget.getOrDefault(category, BigDecimal.ZERO);
+    }
+
+    public int getRemainingEvents(CategoryType category) {
+        return remainingEvents.getOrDefault(category, 0);
+    }
+
+    private double clamp(double value, double min, double max) {
+        return Math.min(max, Math.max(min, value));
+    }
+}

--- a/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/service/SimpleEnvelopeScaler.java
+++ b/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/service/SimpleEnvelopeScaler.java
@@ -1,7 +1,7 @@
 package com.simpaylog.generatorsimulator.service;
 
+import com.simpaylog.generatorcore.dto.CategoryType;
 import com.simpaylog.generatorsimulator.utils.MoneyUtil;
-import com.simpaylog.generatorsimulator.dto.CategoryType;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/service/TradeGenerator.java
+++ b/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/service/TradeGenerator.java
@@ -10,8 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.EnumMap;
 import java.util.List;
-import java.util.Random;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
@@ -20,12 +22,11 @@ import java.util.concurrent.ThreadLocalRandom;
 public class TradeGenerator {
 
     private final TradeInfoLocalCache tradeInfoLocalCache;
-    private final Random random = new Random(); // 확률 및 임의 선택을 위한 Random 인스턴스
 
     /**
      * 입력된 분위와 카테고리를 기반으로 새로운 분위, 임의의 거래 및 해당 거래의 비용을 생성합니다.
      *
-     * @param decile 사용자의 현재 분위 (1~10)
+     * @param decile       사용자의 현재 분위 (1~10)
      * @param categoryType 사용자가 선택한 카테고리 이름 (예: "groceriesNonAlcoholicBeverages")
      * @return 생성된 거래 이름과 비용을 포함하는 TradeResult 객체
      * @throws IllegalArgumentException 유효하지 않은 입력 또는 데이터 부족 시 발생
@@ -45,7 +46,6 @@ public class TradeGenerator {
 
         // 3. 1~10에 대한 발생 확률을 가진 weights를 기반으로, 1~10분위 중 하나를 뽑음 (newDecile)
         int newDecile = selectNewDecile(weights);
-        //log.info("Original Decile: {}, Category: {}, Selected New Decile: {}", decile, categoryName, newDecile);
 
         // 4. 새롭게 뽑은 newDecile, 카테고리 정보를 기반으로 trades 가져옴
         List<TradeInfo.TradeItemDetail> trades = tradeInfoLocalCache.getTradeList(newDecile, categoryType);
@@ -57,9 +57,40 @@ public class TradeGenerator {
         // 5. trades에서 임의의 거래 하나 선택
         TradeInfo.TradeItemDetail selectedTrade = selectRandomTrade(trades);
         // 6. 해당 거래의 min, max값 사이의 값 하나를 cost로 정하기
-        BigDecimal cost = BigDecimal.valueOf(calculateRandomCost(selectedTrade.min(), selectedTrade.max()));
+        BigDecimal cost = BigDecimal.valueOf(ThreadLocalRandom.current().nextInt(selectedTrade.min(), selectedTrade.max() + 1));
         // 7. 임의의 거래 이름 및 cost 반환
         return new Trade(selectedTrade.name(), cost);
+    }
+
+    public Map<CategoryType, Integer> estimateCounts(int decile, Map<CategoryType, BigDecimal> budget) {
+        Map<CategoryType, Integer> out = new EnumMap<>(CategoryType.class);
+        for (Map.Entry<CategoryType, BigDecimal> e : budget.entrySet()) {
+            CategoryType category = e.getKey();
+            BigDecimal averageAmount = meanAmount(decile, category); // 해당 카테고리의 평균 결제 금액
+
+            int N = (averageAmount.signum() > 0) ? e.getValue().divide(averageAmount, 0, RoundingMode.DOWN).intValue() : 1;
+            int clamp = switch (category) {
+                case HOUSING_UTILITIES_FUEL, EDUCATION, COMMUNICATION -> Math.max(1, Math.min(N, 3));
+                case GROCERIES_NON_ALCOHOLIC_BEVERAGES -> Math.max(10, Math.min(N, 80));
+                case FOOD_ACCOMMODATION -> Math.max(4, Math.min(N, 40));
+                default -> Math.max(2, Math.min(N, 30));
+            };
+            out.put(category, clamp);
+        }
+        return out;
+    }
+
+    // 카테고리별 평균 결제 금액
+    private BigDecimal meanAmount(int decile, CategoryType category) {
+        List<TradeInfo.TradeItemDetail> trades = tradeInfoLocalCache.getTradeList(decile, category);
+        if (trades.isEmpty()) return BigDecimal.ZERO;
+
+        double s = 0.0;
+        for (TradeInfo.TradeItemDetail trade : trades) {
+            double avg = (trade.min() + trade.max()) / 2.0;
+            s += avg;
+        }
+        return BigDecimal.valueOf(s / trades.size());
     }
 
     /**
@@ -77,7 +108,7 @@ public class TradeGenerator {
             return 1;
         }
 
-        double randomValue = random.nextDouble() * totalWeight; // 0.0 (inclusive) ~ totalWeight (exclusive)
+        double randomValue = ThreadLocalRandom.current().nextDouble() * totalWeight; // 0.0 (inclusive) ~ totalWeight (exclusive)
         double cumulativeWeight = 0.0;
 
         for (int decile = 1; decile <= weights.size(); decile++) {
@@ -101,25 +132,8 @@ public class TradeGenerator {
         if (trades.isEmpty()) {
             throw new SimulatorException("해당 카테고리의 상품이 비어있습니다.");
         }
-        int randomIdx = random.nextInt(trades.size()); // 0 <= idx < size
+        int randomIdx = ThreadLocalRandom.current().nextInt(trades.size()); // 0 <= idx < size
         return trades.get(randomIdx);
     }
 
-    /**
-     * min과 max 값 사이의 임의의 정수를 계산합니다 (min과 max 포함).
-     *
-     * @param min 최소값
-     * @param max 최대값
-     * @return min과 max 사이의 임의의 정수
-     */
-    private int calculateRandomCost(int min, int max) {
-        // min 값을 100의 배수로 올림 (예: 3600 -> 36)
-        int adjustedMin = (int) Math.ceil(min / 100.0);
-        // max 값을 100의 배수로 내림 (예: 7000 -> 70)
-        int adjustedMax = (int) Math.floor(max / 100.0);
-        // 조정된 범위 내에서 100원 단위 값을 랜덤으로 선택
-        int randomHundreds = ThreadLocalRandom.current().nextInt(adjustedMin, adjustedMax + 1);
-        // 다시 100을 곱하여 최종 비용 반환
-        return randomHundreds * 100;
-    }
 }

--- a/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/service/TransactionService.java
+++ b/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/service/TransactionService.java
@@ -1,5 +1,6 @@
 package com.simpaylog.generatorsimulator.service;
 
+import com.simpaylog.generatorcore.dto.CategoryType;
 import com.simpaylog.generatorcore.dto.DailyTransactionResult;
 import com.simpaylog.generatorcore.dto.TransactionLog;
 import com.simpaylog.generatorcore.entity.Account;
@@ -8,13 +9,11 @@ import com.simpaylog.generatorcore.enums.AccountType;
 import com.simpaylog.generatorcore.enums.WageType;
 import com.simpaylog.generatorcore.repository.redis.RedisPaydayRepository;
 import com.simpaylog.generatorcore.service.AccountService;
-import com.simpaylog.generatorcore.dto.CategoryType;
-import com.simpaylog.generatorsimulator.utils.MoneyUtil;
 import com.simpaylog.generatorsimulator.cache.DecileStatsLocalCache;
-import com.simpaylog.generatorsimulator.dto.CategoryType;
 import com.simpaylog.generatorsimulator.dto.Trade;
 import com.simpaylog.generatorsimulator.kafka.producer.DailyTransactionResultProducer;
 import com.simpaylog.generatorsimulator.kafka.producer.TransactionLogProducer;
+import com.simpaylog.generatorsimulator.utils.MoneyUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -74,7 +73,7 @@ public class TransactionService {
                 curTime = hourStart.plusMinutes(minute);
 
                 // 1. 고정 이벤트 처리
-                if(drainFixedEvents(fixedEvents, curTime)) {
+                if (drainFixedEvents(fixedEvents, curTime)) {
                     continue;
                 }
                 // 2. 해당 시간에 맞는 카테고리 선별하기
@@ -105,7 +104,7 @@ public class TransactionService {
 
     private boolean drainFixedEvents(List<OneTimeEvent> events, LocalDateTime curTime) {
         boolean flag = false;
-        while(!events.isEmpty() && events.getFirst().time().isEqual(curTime)) {
+        while (!events.isEmpty() && events.getFirst().time().isEqual(curTime)) {
             events.removeFirst().run();
             flag = true;
         }
@@ -175,9 +174,9 @@ public class TransactionService {
         List<Integer> minutes = new ArrayList<>(fixed);
 
         int cnt = ThreadLocalRandom.current().nextInt(4);
-        while(cnt-- > 0) {
+        while (cnt-- > 0) {
             int minute = ThreadLocalRandom.current().nextInt(60);
-            if(fixed.add(minute)) minutes.add(minute);
+            if (fixed.add(minute)) minutes.add(minute);
         }
         Collections.sort(minutes);
         return minutes;

--- a/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/service/TransactionService.java
+++ b/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/service/TransactionService.java
@@ -9,6 +9,9 @@ import com.simpaylog.generatorcore.enums.WageType;
 import com.simpaylog.generatorcore.repository.redis.RedisPaydayRepository;
 import com.simpaylog.generatorcore.service.AccountService;
 import com.simpaylog.generatorcore.dto.CategoryType;
+import com.simpaylog.generatorsimulator.utils.MoneyUtil;
+import com.simpaylog.generatorsimulator.cache.DecileStatsLocalCache;
+import com.simpaylog.generatorsimulator.dto.CategoryType;
 import com.simpaylog.generatorsimulator.dto.Trade;
 import com.simpaylog.generatorsimulator.kafka.producer.DailyTransactionResultProducer;
 import com.simpaylog.generatorsimulator.kafka.producer.TransactionLogProducer;
@@ -25,24 +28,36 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static com.simpaylog.generatorsimulator.utils.TransactionSegmentsUtil.*;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class TransactionService {
     private final AccountService accountService;
-    private final TradeGenerator tradeGenerator;
-    private final TransactionGenerator transactionGenerator;
-    private final TransactionLogProducer transactionLogProducer;
     private final DailyTransactionResultProducer dailyTransactionResultProducer;
+    private final TransactionLogProducer transactionLogProducer;
+    private final DecileStatsLocalCache decileStatsLocalCache;
     private final RedisPaydayRepository redisPaydayRepository;
+    private final TransactionGenerator transactionGenerator;
+    private final TradeGenerator tradeGenerator;
+
+    private static final double OVERDRAFT_BASE_PROB = 0.8;
+    private static final double OVERDRAFT_PROB_DELTA = 0.5;
 
     public void generate(TransactionUserDto dto, LocalDate from, LocalDate to) {
-        for (LocalDate date = from; !date.isAfter(to); date = date.plusDays(1)) {
-            generateTransaction(dto, date);
+        for (MonthSegment seg : splitByMonth(from, to)) {
+            Map<CategoryType, BigDecimal> budget = decileStatsLocalCache.getDecileStat(dto.decile());
+            Map<CategoryType, BigDecimal> segBudget = scaleBudget(budget, seg.factor());
+            Map<CategoryType, Integer> eventsCnt = tradeGenerator.estimateCounts(dto.decile(), segBudget);
+            SimpleEnvelopeScaler scaler = new SimpleEnvelopeScaler(segBudget, eventsCnt);
+            for (LocalDate date = seg.start(); !date.isAfter(seg.end()); date = date.plusDays(1)) {
+                generateTransaction(dto, date, scaler);
+            }
         }
     }
 
-    public void generateTransaction(TransactionUserDto dto, LocalDate date) {
+    private void generateTransaction(TransactionUserDto dto, LocalDate date, SimpleEnvelopeScaler scaler) {
         LocalDateTime from = date.atStartOfDay();
         LocalDateTime to = date.atTime(23, 59);
         List<OneTimeEvent> fixedEvents = prepareOneTimeEvents(dto, date);
@@ -54,63 +69,72 @@ public class TransactionService {
             LocalDateTime curTime = from.plusHours(hour);
             List<Integer> minutes = getRandomMinutes(curTime.getHour(), fixedEvents);
             LocalDateTime hourStart = from.plusHours(hour);
+
             for (int minute : minutes) {
                 curTime = hourStart.plusMinutes(minute);
-                boolean fixedTriggered = false;
-                if (!fixedEvents.isEmpty() && fixedEvents.getFirst().time().isEqual(curTime)) {
-                    fixedEvents.removeFirst().run();
-                    fixedTriggered = true;
-                }
-                if (fixedTriggered) continue;
 
+                // 1. 고정 이벤트 처리
+                if(drainFixedEvents(fixedEvents, curTime)) {
+                    continue;
+                }
+                // 2. 해당 시간에 맞는 카테고리 선별하기
                 CategoryType picked = transactionGenerator.pickOneCategory(curTime, dto.preferenceType(), lastUsedMap).orElse(null);
                 if (picked == null) { // 해당 시간에 선택된 카테고리가 없음
                     continue;
                 }
-                // 통장 잔고 마이너스일 시 가중치 높여 제한
-                Account checking = accountService.getAccountByType(dto.userId(), AccountType.CHECKING);
-                if (checking.getBalance().compareTo(BigDecimal.ZERO) < 0) {
-                    double ratio = Math.min(checking.getBalance().abs().doubleValue() / checking.getOverdraftLimit().doubleValue(), 1.0);
-                    double prob = 0.8 - (0.5 * ratio); // 최대 0.3까지 낮춤
-                    if (ThreadLocalRandom.current().nextDouble() > prob) {
-//                        log.info("{} {}원 소비 스킵 prob: {}", dto.userId(), checking.getBalance(), prob);
-                        continue; // 소비 스킵
-                    }
-                }
 
-                // 유저가 해당 카테고리에서 소비한 상품 및 서비스 추출
+                // 3. 발생 가능한 소비인지 점검하기
+                Account checking = accountService.getAccountByType(dto.userId(), AccountType.CHECKING);
+                if (shouldSkipByOverdraft(checking)) continue;
+
+                // 4. 유저가 해당 카테고리에서 소비한 상품 및 금액 추출
                 Trade userTrade = tradeGenerator.generateTrade(dto.decile(), picked);
-                if (accountService.withdraw(dto.userId(), userTrade.cost(), curTime)) { // 잔액 체크 후 해당 카테고리 소비 -> true일 경우
+                BigDecimal scaledAmount = scaler.scale(picked, userTrade.cost());
+                if (scaledAmount.signum() <= 0) continue; // 0원일 경우 건너뜀
+                // 5. 결제 요청
+                if (accountService.withdraw(dto.userId(), scaledAmount, curTime)) { // 잔액 체크 후 해당 카테고리 소비 -> true일 경우
                     lastUsedMap.put(picked, curTime);
-                    generateMessage(TransactionLog.of(dto.userId(), dto.sessionId(), curTime, TransactionLog.TransactionType.WITHDRAW, userTrade.tradeName(), userTrade.cost()));
+                    generateMessage(TransactionLog.of(dto.userId(), dto.sessionId(), curTime, TransactionLog.TransactionType.WITHDRAW, userTrade.tradeName(), scaledAmount));
+                } else {
+                    scaler.rollback(picked, scaledAmount);
                 }
             }
         }
         dailyTransactionResultProducer.send(new DailyTransactionResult(dto.sessionId(), dto.userId(), true, date)); // 웹소켓 결과용 | 유저 한명에 대한 하루 작업 종료
     }
 
+    private boolean drainFixedEvents(List<OneTimeEvent> events, LocalDateTime curTime) {
+        boolean flag = false;
+        while(!events.isEmpty() && events.getFirst().time().isEqual(curTime)) {
+            events.removeFirst().run();
+            flag = true;
+        }
+        return flag;
+    }
+
     private List<OneTimeEvent> prepareOneTimeEvents(TransactionUserDto user, LocalDate date) {
         List<OneTimeEvent> events = new ArrayList<>();
-        // 유저ID, 시간, 입출금 타입, 설명, 금액|(입금 전 금액, 입금 후 금액은 추가 필요)
+
         // 1. 급여 입금 + 저축 로직
         int numberOfPaydays = redisPaydayRepository.numberOfPayDays(user.sessionId(), user.userId(), YearMonth.from(date));
         if (redisPaydayRepository.isPayDay(user.sessionId(), user.userId(), YearMonth.from(date), date)) {
             double averageSalary = user.incomeValue().doubleValue();
             WageType userWageType = user.wageType();
             BigDecimal wage = BigDecimal.valueOf(gaussianRandom(averageSalary / numberOfPaydays, averageSalary * userWageType.getVolatility() / numberOfPaydays));
+            BigDecimal finalWage = MoneyUtil.roundTo10(wage);
             LocalDateTime payTime = date.atTime(ThreadLocalRandom.current().nextInt(7) + 8, ThreadLocalRandom.current().nextInt(60));
             TimedEvent wageEvent = new TimedEvent(
                     payTime,
                     () -> {
-                        accountService.deposit(user.userId(), wage, payTime);
-                        generateMessage(TransactionLog.of(user.userId(), user.sessionId(), payTime, TransactionLog.TransactionType.DEPOSIT, "급여 입금", wage));
+                        accountService.deposit(user.userId(), finalWage, payTime);
+                        generateMessage(TransactionLog.of(user.userId(), user.sessionId(), payTime, TransactionLog.TransactionType.DEPOSIT, "급여 입금", finalWage));
                     }
             );
             events.add(wageEvent);
             LocalDateTime saveTime = date.atTime(LocalTime.from(wageEvent.time().plusMinutes(ThreadLocalRandom.current().nextInt(30) + 1)));
             TimedEvent saveEvent = new TimedEvent(
                     saveTime,
-                    () -> accountService.transferToSavings(user.userId(), wage, user.savingRate(), saveTime)
+                    () -> accountService.transferToSavings(user.userId(), finalWage, user.savingRate(), saveTime)
             );
             events.add(saveEvent);
         }
@@ -130,12 +154,10 @@ public class TransactionService {
 
     private void generateMessage(TransactionLog transactionLog) {
         try {
-//            log.info("로그: {}", transactionLog);
             transactionLogProducer.send(transactionLog);
         } catch (Exception e) {
             // TODO: 필요 시 fallback 로직: DB 적재, 재시도 큐, 알림 등
             log.error("[Kafka Send Fail] userId={}, type={}, time={}, error={}", transactionLog.userId(), transactionLog.transactionType(), transactionLog.timestamp(), e.getMessage());
-            //throw new SimulatorException("카프카 데이터 전송 실패");
         }
     }
 
@@ -149,11 +171,28 @@ public class TransactionService {
     }
 
     private List<Integer> getRandomMinutes(int hour, List<OneTimeEvent> events) {
-        List<Integer> minutes = new ArrayList<>(events.stream().filter(e -> e.time().getHour() == hour).map(e -> e.time().getMinute()).toList());
+        Set<Integer> fixed = new HashSet<>(events.stream().filter(e -> e.time().getHour() == hour).map(e -> e.time().getMinute()).toList());
+        List<Integer> minutes = new ArrayList<>(fixed);
+
         int cnt = ThreadLocalRandom.current().nextInt(4);
-        for (int i = 0; i < cnt; i++) minutes.add(ThreadLocalRandom.current().nextInt(60));
+        while(cnt-- > 0) {
+            int minute = ThreadLocalRandom.current().nextInt(60);
+            if(fixed.add(minute)) minutes.add(minute);
+        }
         Collections.sort(minutes);
         return minutes;
+    }
+
+    // 통장 잔고 마이너스일 시 가중치 높여 제한
+    private boolean shouldSkipByOverdraft(Account checking) {
+        if (checking.getBalance().compareTo((BigDecimal.ZERO)) >= 0) return false;  // 돈이 여유가 있는 경우
+        BigDecimal overDraftLimit = checking.getOverdraftLimit();                   // 마이너스 한도 체크
+        double limit = (overDraftLimit == null) ? 0.0 : overDraftLimit.doubleValue();
+        limit = Math.max(1.0, limit);                                               // 0으로 나누기 방지
+        double ratio = Math.min(checking.getBalance().abs().doubleValue() / limit, 1.0);
+        double prob = OVERDRAFT_BASE_PROB - (OVERDRAFT_PROB_DELTA * ratio);         // 최대 0.3까지 낮춤
+
+        return ThreadLocalRandom.current().nextDouble() > prob;
     }
 
 }

--- a/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/utils/MoneyUtil.java
+++ b/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/utils/MoneyUtil.java
@@ -1,0 +1,50 @@
+package com.simpaylog.generatorsimulator.utils;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class MoneyUtil {
+
+    public static BigDecimal adjust(BigDecimal amount, int unit, RoundingMode mode) {
+        if (amount == null) {
+            throw new IllegalArgumentException("금액(amount)은 null이 될 수 없습니다.");
+        }
+        if (unit <= 0) {
+            throw new IllegalArgumentException("단위(unit)은 0보다 커야 합니다.");
+        }
+        return amount
+                .divide(BigDecimal.valueOf(unit), 0, mode) // 단위로 나누어 반올림/올림/내림
+                .multiply(BigDecimal.valueOf(unit));       // 다시 단위 곱
+    }
+
+    /** 10원 단위 반올림 */
+    public static BigDecimal roundTo10(BigDecimal amount) {
+        return adjust(amount, 10, RoundingMode.HALF_UP);
+    }
+
+    /** 100원 단위 반올림 */
+    public static BigDecimal roundTo100(BigDecimal amount) {
+        return adjust(amount, 100, RoundingMode.HALF_UP);
+    }
+
+    /** 10원 단위 올림 */
+    public static BigDecimal ceilTo10(BigDecimal amount) {
+        return adjust(amount, 10, RoundingMode.CEILING);
+    }
+
+    /** 10원 단위 내림 */
+    public static BigDecimal floorTo10(BigDecimal amount) {
+        return adjust(amount, 10, RoundingMode.FLOOR);
+    }
+
+    /** 100원 단위 올림 */
+    public static BigDecimal ceilTo100(BigDecimal amount) {
+        return adjust(amount, 100, RoundingMode.CEILING);
+    }
+
+    /** 100원 단위 내림 */
+    public static BigDecimal floorTo100(BigDecimal amount) {
+        return adjust(amount, 100, RoundingMode.FLOOR);
+    }
+
+}

--- a/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/utils/TransactionSegmentsUtil.java
+++ b/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/utils/TransactionSegmentsUtil.java
@@ -1,6 +1,6 @@
 package com.simpaylog.generatorsimulator.utils;
 
-import com.simpaylog.generatorsimulator.dto.CategoryType;
+import com.simpaylog.generatorcore.dto.CategoryType;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/utils/TransactionSegmentsUtil.java
+++ b/generator-simulator/src/main/java/com/simpaylog/generatorsimulator/utils/TransactionSegmentsUtil.java
@@ -1,0 +1,50 @@
+package com.simpaylog.generatorsimulator.utils;
+
+import com.simpaylog.generatorsimulator.dto.CategoryType;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+public final class TransactionSegmentsUtil {
+    private static final int INTERNAL_SCALE = 8;
+    private static final RoundingMode RM = RoundingMode.HALF_UP;
+
+    public record MonthSegment(YearMonth ym, LocalDate start, LocalDate end, double factor) {
+    }
+
+    public static List<MonthSegment> splitByMonth(LocalDate from, LocalDate to) {
+        if (from.isAfter(to)) return List.of();
+
+        List<MonthSegment> segs = new ArrayList<>();
+        LocalDate cursor = from;
+        while (!cursor.isAfter(to)) {
+            YearMonth ym = YearMonth.from(cursor);
+            LocalDate monthStart = ym.atDay(1);
+            LocalDate monthEnd = ym.atEndOfMonth();
+
+            LocalDate segStart = cursor.isAfter(monthStart) ? cursor : monthStart; // 둘 중에 늦은 날짜
+            LocalDate segEnd = to.isBefore(monthEnd) ? to : monthEnd; // 둘 중에 빠른 날짜
+
+            int daysInMonth = ym.lengthOfMonth();
+            int days = Math.toIntExact(ChronoUnit.DAYS.between(segStart, segEnd) + 1);
+            double factor = (double) days / (double) daysInMonth; // 기간 비율
+            segs.add(new MonthSegment(ym, segStart, segEnd, factor));
+            cursor = segEnd.plusDays(1); // 다음달로
+        }
+        return segs;
+    }
+
+    public static Map<CategoryType, BigDecimal> scaleBudget(Map<CategoryType, BigDecimal> monthlyBudget, double factor) {
+        Map<CategoryType, BigDecimal> out = new EnumMap<>(CategoryType.class);
+        BigDecimal f = BigDecimal.valueOf(factor);
+        monthlyBudget.forEach((k, v) -> out.put(k, v.multiply(f).setScale(INTERNAL_SCALE, RM))); // 한달 예산 factor 만큼 나누기
+        return out;
+    }
+}

--- a/generator-simulator/src/main/resources/stats.json
+++ b/generator-simulator/src/main/resources/stats.json
@@ -1,0 +1,172 @@
+[
+  {
+    "decile": 1,
+    "byCategory": {
+      "groceriesNonAlcoholicBeverages": 276203,
+      "alcoholicBeveragesTobacco": 23852,
+      "clothingFootwear": 55336,
+      "housingUtilitiesFuel": 275006,
+      "householdGoodsServices": 45998,
+      "health": 124210,
+      "transportation": 77213,
+      "communication": 64072,
+      "recreationCulture": 40236,
+      "education": 7715,
+      "foodAccommodation": 149462,
+      "otherGoodsServices": 75602
+    }
+  },
+  {
+    "decile": 2,
+    "byCategory": {
+      "groceriesNonAlcoholicBeverages": 338813,
+      "alcoholicBeveragesTobacco": 28991,
+      "clothingFootwear": 77181,
+      "housingUtilitiesFuel": 275692,
+      "householdGoodsServices": 64083,
+      "health": 184456,
+      "transportation": 125695,
+      "communication": 79250,
+      "recreationCulture": 59251,
+      "education": 16957,
+      "foodAccommodation": 204974,
+      "otherGoodsServices": 100776
+    }
+  },
+  {
+    "decile": 3,
+    "byCategory": {
+      "groceriesNonAlcoholicBeverages": 335361,
+      "alcoholicBeveragesTobacco": 29263,
+      "clothingFootwear": 90782,
+      "housingUtilitiesFuel": 287301,
+      "householdGoodsServices": 72649,
+      "health": 184735,
+      "transportation": 247133,
+      "communication": 100746,
+      "recreationCulture": 79601,
+      "education": 31887,
+      "foodAccommodation": 264110,
+      "otherGoodsServices": 129174
+    }
+  },
+  {
+    "decile": 4,
+    "byCategory": {
+      "groceriesNonAlcoholicBeverages": 348893,
+      "alcoholicBeveragesTobacco": 35925,
+      "clothingFootwear": 111395,
+      "housingUtilitiesFuel": 344276,
+      "householdGoodsServices": 74805,
+      "health": 178006,
+      "transportation": 198745,
+      "communication": 125624,
+      "recreationCulture": 101108,
+      "education": 49570,
+      "foodAccommodation": 362151,
+      "otherGoodsServices": 159358
+    }
+  },
+  {
+    "decile": 5,
+    "byCategory": {
+      "groceriesNonAlcoholicBeverages": 409535,
+      "alcoholicBeveragesTobacco": 40998,
+      "clothingFootwear": 127221,
+      "housingUtilitiesFuel": 346037,
+      "householdGoodsServices": 111782,
+      "health": 223800,
+      "transportation": 241161,
+      "communication": 161794,
+      "recreationCulture": 125542,
+      "education": 125156,
+      "foodAccommodation": 406009,
+      "otherGoodsServices": 177173
+    }
+  },
+  {
+    "decile": 6,
+    "byCategory": {
+      "groceriesNonAlcoholicBeverages": 460518,
+      "alcoholicBeveragesTobacco": 41915,
+      "clothingFootwear": 164848,
+      "housingUtilitiesFuel": 361606,
+      "householdGoodsServices": 106361,
+      "health": 233995,
+      "transportation": 421353,
+      "communication": 181148,
+      "recreationCulture": 161640,
+      "education": 184321,
+      "foodAccommodation": 460445,
+      "otherGoodsServices": 247705
+    }
+  },
+  {
+    "decile": 7,
+    "byCategory": {
+      "groceriesNonAlcoholicBeverages": 489286,
+      "alcoholicBeveragesTobacco": 39287,
+      "clothingFootwear": 188880,
+      "housingUtilitiesFuel": 363041,
+      "householdGoodsServices": 130107,
+      "health": 265473,
+      "transportation": 316206,
+      "communication": 204951,
+      "recreationCulture": 189396,
+      "education": 241480,
+      "foodAccommodation": 528434,
+      "otherGoodsServices": 241956
+    }
+  },
+  {
+    "decile": 8,
+    "byCategory": {
+      "groceriesNonAlcoholicBeverages": 560710,
+      "alcoholicBeveragesTobacco": 43048,
+      "clothingFootwear": 245963,
+      "housingUtilitiesFuel": 387909,
+      "householdGoodsServices": 150075,
+      "health": 276773,
+      "transportation": 429321,
+      "communication": 211876,
+      "recreationCulture": 235958,
+      "education": 321825,
+      "foodAccommodation": 623440,
+      "otherGoodsServices": 308931
+    }
+  },
+  {
+    "decile": 9,
+    "byCategory": {
+      "groceriesNonAlcoholicBeverages": 606831,
+      "alcoholicBeveragesTobacco": 42677,
+      "clothingFootwear": 265583,
+      "housingUtilitiesFuel": 408928,
+      "householdGoodsServices": 170942,
+      "health": 353158,
+      "transportation": 475916,
+      "communication": 225128,
+      "recreationCulture": 273107,
+      "education": 379446,
+      "foodAccommodation": 691468,
+      "otherGoodsServices": 353362
+    }
+  },
+  {
+    "decile": 10,
+    "byCategory": {
+      "groceriesNonAlcoholicBeverages": 678786,
+      "alcoholicBeveragesTobacco": 44302,
+      "clothingFootwear": 374492,
+      "housingUtilitiesFuel": 437219,
+      "householdGoodsServices": 292348,
+      "health": 388180,
+      "transportation": 692425,
+      "communication": 263407,
+      "recreationCulture": 526565,
+      "education": 450279,
+      "foodAccommodation": 857223,
+      "otherGoodsServices": 542869
+    }
+  }
+]

--- a/generator-simulator/src/test/java/com/simpaylog/generatorsimulator/service/TradeGeneratorTest.java
+++ b/generator-simulator/src/test/java/com/simpaylog/generatorsimulator/service/TradeGeneratorTest.java
@@ -20,7 +20,6 @@ class TradeGeneratorTest extends TestConfig {
     @Autowired
     private TradeGenerator tradeGenerator;
 
-
     //소득분위 및 카테고리 조합을 만드는 함수
     private static Stream<Arguments> provideDecileAndCategoryComb() {
         return IntStream.rangeClosed(1, 10) // 1~10 분위
@@ -44,7 +43,6 @@ class TradeGeneratorTest extends TestConfig {
 
         // 3. cost가 양수이고, 100원 단위로 떨어지는지 확인한다.
         assertThat(trade.cost()).isPositive();
-        assertThat(trade.cost().intValue() % 100).isEqualTo(0); // 비용이 100의 배수인지 확인
         System.out.println(trade.tradeName() + " | " + trade.cost());
     }
 

--- a/generator-simulator/src/test/java/com/simpaylog/generatorsimulator/service/TransactionServiceTest.java
+++ b/generator-simulator/src/test/java/com/simpaylog/generatorsimulator/service/TransactionServiceTest.java
@@ -1,5 +1,6 @@
 package com.simpaylog.generatorsimulator.service;
 
+import com.simpaylog.generatorcore.dto.DailyTransactionResult;
 import com.simpaylog.generatorcore.dto.TransactionLog;
 import com.simpaylog.generatorcore.entity.Account;
 import com.simpaylog.generatorcore.entity.dto.TransactionUserDto;
@@ -9,20 +10,28 @@ import com.simpaylog.generatorcore.enums.WageType;
 import com.simpaylog.generatorcore.repository.redis.RedisPaydayRepository;
 import com.simpaylog.generatorcore.service.AccountService;
 import com.simpaylog.generatorsimulator.TestConfig;
+import com.simpaylog.generatorsimulator.cache.DecileStatsLocalCache;
+import com.simpaylog.generatorsimulator.dto.CategoryType;
+import com.simpaylog.generatorsimulator.dto.Trade;
 import com.simpaylog.generatorcore.dto.CategoryType;
 import com.simpaylog.generatorsimulator.kafka.producer.DailyTransactionResultProducer;
 import com.simpaylog.generatorsimulator.kafka.producer.TransactionLogProducer;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -37,43 +46,155 @@ class TransactionServiceTest extends TestConfig {
     @MockitoBean
     DailyTransactionResultProducer dailyTransactionResultProducer;
     @MockitoBean
+    DecileStatsLocalCache decileStatsLocalCache;
+    @MockitoBean
     TransactionGenerator transactionGenerator;
+    @MockitoBean
+    TradeGenerator tradeGenerator;
     @MockitoBean
     AccountService accountService;
     @MockitoBean
     RedisPaydayRepository redisPaydayRepository;
 
+    // 0. 정상 케이스
     @Test
-    void 트랜잭션이_정상적으로_생성되면_총합과_카운트가_일치한다() {
+    void 정상케이스_최대한_예산금액에_맞춰서_결제_금액을_생성한다() {
         // Given
-        TransactionUserDto mockUser = mockUser(3, WageType.REGULAR);
-        LocalDate date = LocalDate.of(2025, 7, 1);
-        when(accountService.getAccountByType(mockUser.userId(), AccountType.CHECKING)).thenReturn(createCheckingAccount(BigDecimal.valueOf(50000), BigDecimal.ZERO));
-        when(transactionGenerator.pickOneCategory(any(LocalDateTime.class), any(PreferenceType.class), anyMap())).thenReturn(Optional.of(CategoryType.ALCOHOLIC_BEVERAGES_TOBACCO));
-        when(accountService.withdraw(anyLong(), any(BigDecimal.class), any())).thenReturn(true);
+        int userDecile = 1;
+        int budget = 310000;
+        TransactionUserDto mockUser = mockUser(userDecile, WageType.REGULAR);
+        LocalDate from = LocalDate.of(2025, 7, 1);
+        LocalDate to = LocalDate.of(2025, 7, 3);
+        int days = Math.toIntExact(ChronoUnit.DAYS.between(from, to) + 1);
+        // 1. 월 예산 설정
+        var monthlyStats = new EnumMap<CategoryType, BigDecimal>(CategoryType.class);
+        monthlyStats.put(CategoryType.GROCERIES_NON_ALCOHOLIC_BEVERAGES, BigDecimal.valueOf(budget));
+        when(decileStatsLocalCache.getDecileStat(anyInt())).thenReturn(monthlyStats);
+
+        // 2. 소비 횟수 설정
+        when(tradeGenerator.estimateCounts(anyInt(), anyMap()))
+                .thenAnswer(invocation -> {
+                            Map<CategoryType, BigDecimal> segBudget = invocation.getArgument(1);
+                            Map<CategoryType, Integer> cnt = new EnumMap<>(CategoryType.class);
+                            segBudget.forEach((k, v) -> {
+                                int n = v.divide(BigDecimal.valueOf(20000), 0, RoundingMode.DOWN).intValue();
+                                cnt.put(k, Math.max(1, n));
+                            });
+                            return cnt;
+                        }
+                );
+
+        // 3. 카테고리 설정
+        when(transactionGenerator.pickOneCategory(any(), any(), anyMap()))
+                .thenReturn(Optional.of(CategoryType.GROCERIES_NON_ALCOHOLIC_BEVERAGES));
+        // 4. 상품 설정
+        when(tradeGenerator.generateTrade(anyInt(), any()))
+                .thenReturn(new Trade("과일세트", BigDecimal.valueOf(20000)));
+        // 5. 금액 체크
+        when(accountService.getAccountByType(anyLong(), eq(AccountType.CHECKING)))
+                .thenReturn(createCheckingAccount(BigDecimal.valueOf(100000), BigDecimal.ZERO));
+        // 6. 결제 성공
+        when(accountService.withdraw(anyLong(), any(BigDecimal.class), any(LocalDateTime.class)))
+                .thenReturn(true);
         // When
-        transactionService.generateTransaction(mockUser, date);
+        transactionService.generate(mockUser, from, to);
+        // Then
+
+        // 출금된 금액 체크
+        ArgumentCaptor<BigDecimal> captor = ArgumentCaptor.forClass(BigDecimal.class);
+        verify(accountService, atLeastOnce()).withdraw(any(), captor.capture(), any());
+        BigDecimal spent = captor.getAllValues().stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // 세그먼트 예산 = 월예산 × (3 / 31) -> 5%이내의 오차
+        BigDecimal segBudget = new BigDecimal(budget)
+                .multiply(BigDecimal.valueOf((double) days / (double) from.getDayOfMonth()));
+        assertTrue(spent.compareTo(segBudget.multiply(new BigDecimal("1.05"))) <= 0, "spent should be ≤ segBudget(±5%)"); // 전체 지출 금액은 예산의 5%이내에 수렴
+
+        // 결과 전송 호출여부
+        verify(dailyTransactionResultProducer, atLeastOnce()).send(any(DailyTransactionResult.class));
+    }
+
+    // 1. 고정 이벤트 처리 여부
+
+    // 2. 뽑힌 카테고리가 없을 경우
+    @Test
+    void 실패케이스_뽑힌_카테고리가_없을경우_결제가_일어나지_않는다() {
+        // Given
+        int userDecile = 1;
+        int budget = 310000;
+        TransactionUserDto mockUser = mockUser(userDecile, WageType.REGULAR);
+        LocalDate from = LocalDate.of(2025, 7, 1);
+        LocalDate to = LocalDate.of(2025, 7, 3);
+        // 1. 월 예산 설정
+        var monthlyStats = new EnumMap<CategoryType, BigDecimal>(CategoryType.class);
+        monthlyStats.put(CategoryType.GROCERIES_NON_ALCOHOLIC_BEVERAGES, BigDecimal.valueOf(budget));
+        when(decileStatsLocalCache.getDecileStat(anyInt())).thenReturn(monthlyStats);
+
+        // 2. 소비 횟수 설정
+        when(tradeGenerator.estimateCounts(anyInt(), anyMap()))
+                .thenAnswer(invocation -> {
+                            Map<CategoryType, BigDecimal> segBudget = invocation.getArgument(1);
+                            Map<CategoryType, Integer> cnt = new EnumMap<>(CategoryType.class);
+                            segBudget.forEach((k, v) -> {
+                                int n = v.divide(BigDecimal.valueOf(20000), 0, RoundingMode.DOWN).intValue();
+                                cnt.put(k, Math.max(1, n));
+                            });
+                            return cnt;
+                        }
+                );
+        when(transactionGenerator.pickOneCategory(any(), any(), anyMap()))
+                .thenReturn(Optional.empty());
+
+        // When
+        transactionService.generate(mockUser, from, to);
 
         // Then
-        verify(transactionLogProducer, atLeastOnce()).send(any());
-        verify(dailyTransactionResultProducer, times(1)).send(any());
+        verify(transactionLogProducer, never()).send(any(TransactionLog.class));
+        verify(dailyTransactionResultProducer, atLeastOnce()).send(any(DailyTransactionResult.class));
+
     }
 
     @Test
-    void 해당일자가_급여일일_경우_입금관련_트랜잭션_로그를_발생시킨다() {
+    void 실패케이스_출금_실패시_롤백한다() {
         // Given
-        TransactionUserDto mockUser = mockUser(3, WageType.REGULAR);
-        LocalDate date = LocalDate.of(2025, 7, 25);
-        LocalDate paymentDay = LocalDate.of(2025, 7, 25);
-        when(redisPaydayRepository.isPayDay(anyString(), eq(mockUser.userId()), eq(YearMonth.of(2025, 7)), eq(paymentDay))).thenReturn(true);
-        when(redisPaydayRepository.numberOfPayDays(anyString(), eq(mockUser.userId()), eq(YearMonth.of(2025, 7)))).thenReturn(1);
+        int userDecile = 1;
+        int budget = 310000;
+        TransactionUserDto mockUser = mockUser(userDecile, WageType.REGULAR);
+        LocalDate from = LocalDate.of(2025, 7, 1);
+        LocalDate to = LocalDate.of(2025, 7, 3);
+        // 1. 월 예산 설정
+        var monthlyStats = new EnumMap<CategoryType, BigDecimal>(CategoryType.class);
+        monthlyStats.put(CategoryType.GROCERIES_NON_ALCOHOLIC_BEVERAGES, BigDecimal.valueOf(budget));
+        when(decileStatsLocalCache.getDecileStat(anyInt())).thenReturn(monthlyStats);
+
+        // 2. 소비 횟수 설정
+        when(tradeGenerator.estimateCounts(anyInt(), anyMap()))
+                .thenAnswer(invocation -> {
+                            Map<CategoryType, BigDecimal> segBudget = invocation.getArgument(1);
+                            Map<CategoryType, Integer> cnt = new EnumMap<>(CategoryType.class);
+                            segBudget.forEach((k, v) -> {
+                                int n = v.divide(BigDecimal.valueOf(20000), 0, RoundingMode.DOWN).intValue();
+                                cnt.put(k, Math.max(1, n));
+                            });
+                            return cnt;
+                        }
+                );
+
+        // 3. 카테고리 설정
+        when(transactionGenerator.pickOneCategory(any(), any(), anyMap()))
+                .thenReturn(Optional.of(CategoryType.GROCERIES_NON_ALCOHOLIC_BEVERAGES));
+        // 4. 상품 설정
+        when(tradeGenerator.generateTrade(anyInt(), any()))
+                .thenReturn(new Trade("과일세트", BigDecimal.valueOf(20000)));
+        // 5. 금액 체크
+        when(accountService.getAccountByType(anyLong(), eq(AccountType.CHECKING)))
+                .thenReturn(createCheckingAccount(BigDecimal.valueOf(10000), BigDecimal.ZERO));
         // When
-        transactionService.generateTransaction(mockUser, date);
+        transactionService.generate(mockUser, from, to);
+
         // Then
-        verify(transactionLogProducer, times(1)).send(argThat(log ->
-                log.transactionType() == TransactionLog.TransactionType.DEPOSIT &&
-                        log.description().equals("급여 입금")
-        ));
+        verify(transactionLogProducer, never()).send(any(TransactionLog.class));
+        verify(dailyTransactionResultProducer, atLeastOnce()).send(any(DailyTransactionResult.class));
     }
 
     private TransactionUserDto mockUser(int decile, WageType wageType) {
@@ -89,6 +210,7 @@ class TransactionServiceTest extends TestConfig {
                 BigDecimal.ZERO
         );
     }
+
     private Account createCheckingAccount(BigDecimal balance, BigDecimal overDraftLimit) {
         return Account.ofChecking(balance, overDraftLimit);
     }

--- a/generator-simulator/src/test/java/com/simpaylog/generatorsimulator/service/TransactionServiceTest.java
+++ b/generator-simulator/src/test/java/com/simpaylog/generatorsimulator/service/TransactionServiceTest.java
@@ -11,7 +11,6 @@ import com.simpaylog.generatorcore.repository.redis.RedisPaydayRepository;
 import com.simpaylog.generatorcore.service.AccountService;
 import com.simpaylog.generatorsimulator.TestConfig;
 import com.simpaylog.generatorsimulator.cache.DecileStatsLocalCache;
-import com.simpaylog.generatorsimulator.dto.CategoryType;
 import com.simpaylog.generatorsimulator.dto.Trade;
 import com.simpaylog.generatorcore.dto.CategoryType;
 import com.simpaylog.generatorsimulator.kafka.producer.DailyTransactionResultProducer;

--- a/generator-simulator/src/test/java/com/simpaylog/generatorsimulator/utils/TransactionSegmentsUtilTest.java
+++ b/generator-simulator/src/test/java/com/simpaylog/generatorsimulator/utils/TransactionSegmentsUtilTest.java
@@ -1,0 +1,33 @@
+package com.simpaylog.generatorsimulator.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TransactionSegmentsUtilTest {
+
+    @Test
+    void 경계테스트_걸쳐있는_기간을_줬을때_2개의_MonthSegment를_가진_리스트를_생성() {
+        // Given
+        LocalDate from = LocalDate.of(2025, 8, 29);
+        LocalDate to = LocalDate.of(2025, 9, 2);
+
+        // When
+        var segs = TransactionSegmentsUtil.splitByMonth(from, to);
+
+        // Then
+        assertEquals(2, segs.size());
+        assertEquals(YearMonth.of(2025, 8), segs.getFirst().ym());
+        assertEquals(LocalDate.of(2025, 8, 29), segs.getFirst().start());
+        assertEquals(LocalDate.of(2025, 8, 31), segs.getFirst().end());
+        assertEquals(YearMonth.of(2025, 9), segs.getLast().ym());
+        assertEquals(LocalDate.of(2025, 9, 1), segs.getLast().start());
+        assertEquals(LocalDate.of(2025, 9, 2), segs.getLast().end());
+    }
+
+}


### PR DESCRIPTION
## 1. PR 내용
1. 소득분위별 카테고리 지출 금액에 기반한 소비 금액 데이터 조정
    1. 소득분위별 카테고리 거래 금액 Json에서 읽어오기
    2.  기간별 예산 설정(월별 예산 설정 | 기간이 30일에 미치지 못할 경우 예산 조정)
    3. 각 카테고리별 소비 횟수 설정
        * case HOUSING_UTILITIES_FUEL, EDUCATION, COMMUNICATION -> Math.max(1, Math.min(N, 3));
        * case GROCERIES_NON_ALCOHOLIC_BEVERAGES -> Math.max(10, Math.min(N, 80));
        * case FOOD_ACCOMMODATION -> Math.max(4, Math.min(N, 40));
        * default -> Math.max(2, Math.min(N, 30));
      -> 설정 기준 : 해당 카테고리의 소비 항목들의 평균을 계산 -> 전체 금액 / 평균 금액 = 한번 소비할 평균 금액
    4.  시뮬레이션 시작
    5. 카테고리 픽
    6. 카테고리 내 상품 픽
    7. 상품의 금액 스케일 조정 -> 많이 안썼다면 금액을 높임
## 2. CheckList
- [x] 통합테스트
- [x] 테스트코드작성

## 3. TODO
- 급여 금액 및 소비 성향에 기반한 커스텀 수치 반영 필요