### PR TITLE
[BE] 개인 집단 분석 api 설계

### DIFF
--- a/generator-api/src/main/java/com/simpaylog/generatorapi/controller/AnalysisController.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/controller/AnalysisController.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/analysis")
@@ -30,9 +29,9 @@ public class AnalysisController {
             @RequestParam LocalDate durationStart,
             @RequestParam LocalDate durationEnd,
             @RequestParam String interval,
-            @RequestParam Optional<Integer> userId
+            @RequestParam(required = false) Integer userId
     ) throws IOException {
-        return Response.success(HttpStatus.OK.value(), analysisService.searchByPeriod(sessionId, durationStart, durationEnd, interval, userId.orElse(null)));
+        return Response.success(HttpStatus.OK.value(), analysisService.searchByPeriod(sessionId, durationStart, durationEnd, interval, userId));
     }
 
     //전체 - 개인 월별 수입/지출 금액 비교
@@ -42,9 +41,9 @@ public class AnalysisController {
             @RequestParam LocalDate durationStart,
             @RequestParam LocalDate durationEnd,
             @RequestParam String interval,
-            @RequestParam Optional<Integer> userId
+            @RequestParam(required = false) Integer userId
     ) throws IOException {
-        return Response.success(HttpStatus.OK.value(), analysisService.searchPeriodAmount(sessionId, durationStart, durationEnd, interval, userId.orElse(null)));
+        return Response.success(HttpStatus.OK.value(), analysisService.searchPeriodAmount(sessionId, durationStart, durationEnd, interval, userId));
     }
 
     @GetMapping("/time-heatmap")
@@ -70,9 +69,9 @@ public class AnalysisController {
             @RequestParam String sessionId,
             @RequestParam LocalDate durationStart,
             @RequestParam LocalDate durationEnd,
-            @RequestParam Optional<Integer> userId
+            @RequestParam(required = false) Integer userId
     ) throws IOException {
-        return Response.success(HttpStatus.OK.value(), analysisService.searchUserTradeAmountAvgByUserId(sessionId, durationStart, durationEnd, userId.orElse(null)));
+        return Response.success(HttpStatus.OK.value(), analysisService.searchUserTradeAmountAvgByUserId(sessionId, durationStart, durationEnd, userId));
     }
 
     @GetMapping("/all-category-info")
@@ -98,9 +97,9 @@ public class AnalysisController {
             @RequestParam String sessionId,
             @RequestParam LocalDate durationStart,
             @RequestParam LocalDate durationEnd,
-            @RequestParam Optional<Integer> userId
+            @RequestParam(required = false) Integer userId
     ) throws IOException {
-        return Response.success(HttpStatus.OK.value(), analysisService.searchUserCategoryTradeAmount(sessionId, durationStart, durationEnd, userId.orElse(null)));
+        return Response.success(HttpStatus.OK.value(), analysisService.searchUserCategoryTradeAmount(sessionId, durationStart, durationEnd, userId));
     }
 
     @GetMapping("/category/by-age-group")

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/controller/AnalysisController.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/controller/AnalysisController.java
@@ -29,20 +29,22 @@ public class AnalysisController {
             @RequestParam String sessionId,
             @RequestParam LocalDate durationStart,
             @RequestParam LocalDate durationEnd,
-            @RequestParam String interval
+            @RequestParam String interval,
+            @RequestParam Optional<Integer> userId
     ) throws IOException {
-        return Response.success(HttpStatus.OK.value(), analysisService.searchByPeriod(sessionId, durationStart, durationEnd, interval, null));
+        return Response.success(HttpStatus.OK.value(), analysisService.searchByPeriod(sessionId, durationStart, durationEnd, interval, userId.orElse(null)));
     }
 
-    @GetMapping("/search-by-period-and-id")
-    public Response<CommonChart<PeriodTransaction.PTSummary>> searchByPeriod(
+    //전체 - 개인 월별 수입/지출 금액 비교
+    @GetMapping("/search-period-amount")
+    public Response<CommonChart<PeriodTransaction.PTSummary>> searchPeriodAmount(
             @RequestParam String sessionId,
             @RequestParam LocalDate durationStart,
             @RequestParam LocalDate durationEnd,
             @RequestParam String interval,
-            @RequestParam Integer userId
+            @RequestParam Optional<Integer> userId
     ) throws IOException {
-        return Response.success(HttpStatus.OK.value(), analysisService.searchByPeriod(sessionId, durationStart, durationEnd, interval, userId));
+        return Response.success(HttpStatus.OK.value(), analysisService.searchPeriodAmount(sessionId, durationStart, durationEnd, interval, userId.orElse(null)));
     }
 
     @GetMapping("/time-heatmap")

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/controller/AnalysisController.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/controller/AnalysisController.java
@@ -1,6 +1,6 @@
 package com.simpaylog.generatorapi.controller;
 
-import com.simpaylog.generatorapi.dto.analysis.AmountAvgTransaction;
+import com.simpaylog.generatorapi.dto.analysis.AmountTransaction;
 import com.simpaylog.generatorapi.dto.analysis.HourlyTransaction;
 import com.simpaylog.generatorapi.dto.analysis.PeriodTransaction;
 import com.simpaylog.generatorapi.dto.analysis.TimeHeatmapCell;
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/analysis")
@@ -66,13 +67,13 @@ public class AnalysisController {
     }
 
     @GetMapping("/amount-avg/by-transaction-type")
-    public Response<CommonChart<AmountAvgTransaction.AmountAvgTransactionSummary>> searchTypeAmountAvgByPeriod(
+    public Response<CommonChart<AmountTransaction.AmountAvgTransactionSummary>> searchTypeAmountAvgByPeriod(
             @RequestParam String sessionId,
             @RequestParam LocalDate durationStart,
             @RequestParam LocalDate durationEnd,
-            @RequestParam Integer userId
+            @RequestParam Optional<Integer> userId
     ) throws IOException {
-        return Response.success(HttpStatus.OK.value(), analysisService.searchUserTradeAmountAvgByUserId(sessionId, durationStart, durationEnd, userId));
+        return Response.success(HttpStatus.OK.value(), analysisService.searchUserTradeAmountAvgByUserId(sessionId, durationStart, durationEnd, userId.orElse(null)));
     }
 
     @GetMapping("/all-category-info")

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/controller/AnalysisController.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/controller/AnalysisController.java
@@ -1,9 +1,6 @@
 package com.simpaylog.generatorapi.controller;
 
-import com.simpaylog.generatorapi.dto.analysis.AmountTransaction;
-import com.simpaylog.generatorapi.dto.analysis.HourlyTransaction;
-import com.simpaylog.generatorapi.dto.analysis.PeriodTransaction;
-import com.simpaylog.generatorapi.dto.analysis.TimeHeatmapCell;
+import com.simpaylog.generatorapi.dto.analysis.*;
 import com.simpaylog.generatorapi.dto.chart.ChartData;
 import com.simpaylog.generatorapi.dto.response.CommonChart;
 import com.simpaylog.generatorapi.dto.response.Response;
@@ -67,7 +64,7 @@ public class AnalysisController {
     }
 
     @GetMapping("/amount-avg/by-transaction-type")
-    public Response<CommonChart<AmountTransaction.AmountAvgTransactionSummary>> searchTypeAmountAvgByPeriod(
+    public Response<CommonChart<AmountTransaction.AmountTransactionSummary>> searchTypeAmountAvgByPeriod(
             @RequestParam String sessionId,
             @RequestParam LocalDate durationStart,
             @RequestParam LocalDate durationEnd,
@@ -78,9 +75,9 @@ public class AnalysisController {
 
     @GetMapping("/all-category-info")
     public Response<?> searchAllCategoryInfo(
-            @RequestParam String sessionId,
-            @RequestParam String durationStart,
-            @RequestParam String durationEnd
+    @RequestParam String sessionId,
+    @RequestParam String durationStart,
+    @RequestParam String durationEnd
     ) {
         return Response.success(HttpStatus.OK.value(), analysisService.searchAllCategoryInfo(sessionId, durationStart, durationEnd));
     }
@@ -92,6 +89,16 @@ public class AnalysisController {
             @RequestParam String durationEnd
     ) {
         return Response.success(HttpStatus.OK.value(), analysisService.searchCategoryByVomlumeTop5(sessionId, durationStart, durationEnd));
+    }
+
+    @GetMapping("/category/by-userId")
+    public Response<CommonChart<CategoryAmountTransaction.AmountTransactionSummary>> searchUserCategoryTradeAmount(
+            @RequestParam String sessionId,
+            @RequestParam LocalDate durationStart,
+            @RequestParam LocalDate durationEnd,
+            @RequestParam Optional<Integer> userId
+    ) throws IOException {
+        return Response.success(HttpStatus.OK.value(), analysisService.searchUserCategoryTradeAmount(sessionId, durationStart, durationEnd, userId.orElse(null)));
     }
 
     @GetMapping("/category/by-age-group")

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/dto/analysis/AmountTransaction.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/dto/analysis/AmountTransaction.java
@@ -2,11 +2,11 @@ package com.simpaylog.generatorapi.dto.analysis;
 
 import java.util.List;
 
-public record AmountAvgTransaction(
+public record AmountTransaction(
         List<AmountAvgTransactionSummary> results
 ){
     public record AmountAvgTransactionSummary(
             String transactionType,
-            int avgAmount
+            int amount
     ) {}
 }

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/dto/analysis/CategoryAmountTransaction.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/dto/analysis/CategoryAmountTransaction.java
@@ -2,11 +2,11 @@ package com.simpaylog.generatorapi.dto.analysis;
 
 import java.util.List;
 
-public record AmountTransaction(
-        List<AmountTransactionSummary> results
+public record CategoryAmountTransaction(
+        List<CategoryAmountTransaction.AmountTransactionSummary> results
 ){
     public record AmountTransactionSummary(
-            String transactionType,
+            String categoryType,
             int amount
     ) {}
 }

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/repository/Elasticsearch/TransactionAggregationRepository.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/repository/Elasticsearch/TransactionAggregationRepository.java
@@ -145,9 +145,9 @@ public class TransactionAggregationRepository {
         return new HourlyTransaction(summaries);
     }
 
-    public AmountAvgTransaction searchUserTradeAmountAvgByUserId(String sessionId, LocalDate from, LocalDate to, int userId) throws IOException {
+    public AmountTransaction searchUserTradeAmountAvgByUserId(String sessionId, LocalDate from, LocalDate to, Integer userId) throws IOException {
         Request request = new Request("GET", ES_END_POINT);
-        String queryJson = QueryBuilder.userTradeAmountAvgQuery(sessionId, from, to, userId);
+        String queryJson = QueryBuilder.userTradeAmountQuery(sessionId, from, to, userId);
         request.setJsonEntity(queryJson);
 
         Response response = elasticsearchRestClient.performRequest(request);
@@ -157,14 +157,14 @@ public class TransactionAggregationRepository {
         JsonNode root = objectMapper.readTree(jsonResult);
         JsonNode buckets = root.path("aggregations").path("by_type").path("buckets");
 
-        List<AmountAvgTransaction.AmountAvgTransactionSummary> summaries = new ArrayList<>();
+        List<AmountTransaction.AmountAvgTransactionSummary> summaries = new ArrayList<>();
         for (JsonNode bucket : buckets) {
             String transactionType = bucket.path("key").asText();
-            int avgAmount = bucket.path("average_amount").path("value").asInt(0);
-            summaries.add(new AmountAvgTransaction.AmountAvgTransactionSummary(transactionType, avgAmount));
+            int avgAmount = bucket.path("total_amount").path("value").asInt(0);
+            summaries.add(new AmountTransaction.AmountAvgTransactionSummary(transactionType, avgAmount));
         }
 
-        return new AmountAvgTransaction(summaries);
+        return new AmountTransaction(summaries);
     }
 
 

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/service/AnalysisService.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/service/AnalysisService.java
@@ -61,11 +61,11 @@ public class AnalysisService {
         return new CommonChart<>("line", "시간 별 트랜잭션 발생 금액 평균", "시간", "평균 금액", result.results());
     }
 
-    public CommonChart<AmountAvgTransaction.AmountAvgTransactionSummary> searchUserTradeAmountAvgByUserId(String sessionId, LocalDate durationStart, LocalDate durationEnd, Integer userId) throws IOException {
+    public CommonChart<AmountTransaction.AmountAvgTransactionSummary> searchUserTradeAmountAvgByUserId(String sessionId, LocalDate durationStart, LocalDate durationEnd, Integer userId) throws IOException {
         getSimulationSessionOrException(sessionId);
         DateValidator.validateDateRange(durationStart, durationEnd);
-        AmountAvgTransaction result = transactionAggregationRepository.searchUserTradeAmountAvgByUserId(sessionId, durationStart, durationEnd, userId);
-        return new CommonChart<>("line", "수입/지출 금액 평균", "거래 종류", "평균 금액", result.results());
+        AmountTransaction result = transactionAggregationRepository.searchUserTradeAmountAvgByUserId(sessionId, durationStart, durationEnd, userId);
+        return new CommonChart<>("line", "수입/지출 금액 평균", "거래 종류", "총 금액", result.results());
     }
 
     private void getSimulationSessionOrException(String sessionId) {

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/service/AnalysisService.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/service/AnalysisService.java
@@ -35,10 +35,22 @@ public class AnalysisService {
     private final UserRepository userRepository;
 
     public CommonChart<PeriodTransaction.PTSummary> searchByPeriod(String sessionId, LocalDate durationStart, LocalDate durationEnd, String interval, Integer userId) throws IOException {
-        getSimulationSessionOrException(sessionId);
+//        getSimulationSessionOrException(sessionId);
         DateValidator.validateDateRange(durationStart, durationEnd);
         AggregationInterval aggregationInterval = AggregationInterval.from(interval);
         PeriodTransaction result = transactionAggregationRepository.searchByPeriod(sessionId, durationStart, durationEnd, aggregationInterval, userId);
+        return switch (aggregationInterval) {
+            case DAY -> new CommonChart<>("line", "일 별 트랜잭션 발생 금액", "날짜", "금액", result.results());
+            case WEEK -> new CommonChart<>("line", "주 별 트랜잭션 발생 금액", "날짜", "금액", result.results());
+            case MONTH -> new CommonChart<>("line", "월 별 트랜잭션 발생 금액", "날짜", "금액", result.results());
+        };
+    }
+
+    public CommonChart<PeriodTransaction.PTSummary> searchPeriodAmount(String sessionId, LocalDate durationStart, LocalDate durationEnd, String interval, Integer userId) throws IOException {
+        getSimulationSessionOrException(sessionId);
+        DateValidator.validateDateRange(durationStart, durationEnd);
+        AggregationInterval aggregationInterval = AggregationInterval.from(interval);
+        PeriodTransaction result = transactionAggregationRepository.searchPeriodAmount(sessionId, durationStart, durationEnd, aggregationInterval, userId);
         return switch (aggregationInterval) {
             case DAY -> new CommonChart<>("line", "일 별 트랜잭션 발생 금액", "날짜", "금액", result.results());
             case WEEK -> new CommonChart<>("line", "주 별 트랜잭션 발생 금액", "날짜", "금액", result.results());

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/service/AnalysisService.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/service/AnalysisService.java
@@ -61,11 +61,18 @@ public class AnalysisService {
         return new CommonChart<>("line", "시간 별 트랜잭션 발생 금액 평균", "시간", "평균 금액", result.results());
     }
 
-    public CommonChart<AmountTransaction.AmountAvgTransactionSummary> searchUserTradeAmountAvgByUserId(String sessionId, LocalDate durationStart, LocalDate durationEnd, Integer userId) throws IOException {
+    public CommonChart<AmountTransaction.AmountTransactionSummary> searchUserTradeAmountAvgByUserId(String sessionId, LocalDate durationStart, LocalDate durationEnd, Integer userId) throws IOException {
         getSimulationSessionOrException(sessionId);
         DateValidator.validateDateRange(durationStart, durationEnd);
-        AmountTransaction result = transactionAggregationRepository.searchUserTradeAmountAvgByUserId(sessionId, durationStart, durationEnd, userId);
+        AmountTransaction result = transactionAggregationRepository.searchUserTradeAmountByUserId(sessionId, durationStart, durationEnd, userId);
         return new CommonChart<>("line", "수입/지출 금액 평균", "거래 종류", "총 금액", result.results());
+    }
+
+    public CommonChart<CategoryAmountTransaction.AmountTransactionSummary> searchUserCategoryTradeAmount(String sessionId, LocalDate durationStart, LocalDate durationEnd, Integer userId) throws IOException {
+        getSimulationSessionOrException(sessionId);
+        DateValidator.validateDateRange(durationStart, durationEnd);
+        CategoryAmountTransaction result = transactionAggregationRepository.searchUserCategoryTradeAmount(sessionId, durationStart, durationEnd, userId);
+        return new CommonChart<>("line", "카테고리별 수입/지출", "카테고리 종류", "총 금액", result.results());
     }
 
     private void getSimulationSessionOrException(String sessionId) {

--- a/generator-core/src/main/java/com/simpaylog/generatorcore/dto/response/UserInfoResponse.java
+++ b/generator-core/src/main/java/com/simpaylog/generatorcore/dto/response/UserInfoResponse.java
@@ -4,6 +4,7 @@ import com.simpaylog.generatorcore.entity.User;
 import com.simpaylog.generatorcore.enums.Gender;
 
 public record UserInfoResponse(
+        Long userId,
         String name,
         Gender gender,
         Integer age,
@@ -12,6 +13,7 @@ public record UserInfoResponse(
 
     public static UserInfoResponse userToUserInfoResponse(User user) {
         return new UserInfoResponse(
+                user.getId(),
                 user.getName(),
                 user.getGender(),
                 user.getAge(),


### PR DESCRIPTION
userId를 기반으로 하는 통계 쿼리 구현

## 변경점
1. 특정 user / 전체 카테고리 amount 통계 쿼리 구현
  - 개인별 카테고리별 수입/지출 정보를 얻어오는 로직 구현(api에 userId 입력시 개인 수입/지출 정보 받아옴)
  - 전체 유저의 카테고리별 수입/지출 정보를 얻어오는 로직 구현(api에 userId 입력시 개인 수입/지출 정보 받아옴)
  - CategoryAmountTransaction DTO 사용. 해당 DTO 연관된 로직 구현
  - "/amount-avg/by-transaction-type" 로 매핑된 api 주소 사용
 
2. 특정 user / 전체 월별 amount 통계 쿼리 구현
  - 개인별 월간 수입/지출 정보를 얻어오는 로직 구현(api에 userId 입력시 개인 수입/지출 정보 받아옴)
  - 전체 유저의 월간 수입/지출 정보를 얻어오는 로직 구현(api에 userId 미입력시 개인 수입/지출 정보 받아옴)
  - 기존에 있던 PeriodTransaction DTO 사용, 
  - "/search-period-amount"로 매핑된 api 주소 사용
 
3. 쿼리를 통해 amount의 평균을 구하던 로직 및 DTO 변경
  - 쿼리를 통해 평균을 계산하는 로직들에 오류가 있어, WITHDRAW 혹은 DEPOSIT의 amount 총 합을 구하는 로직으로 변경
  - WITHDRAW/DEPOSIT의 amount총합을 구해봐 FrontEnd에서 값을 계산하여 사용하는 방식으로 변경함(퍼센트 구하기 정도의 계산)
  - AmountAvgTransation -> AmountTrasaction로 DTO 변경 및 관련 로직 변경

## 체크리스트
- [x] 무엇을 변경했는지 설명

## 관련 이슈
- Closes #77 