### PR TITLE
[BE] 유저 거래 내역 조회 API 추가

### DIFF
--- a/generator-api/src/main/java/com/simpaylog/generatorapi/controller/AnalysisController.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/controller/AnalysisController.java
@@ -5,15 +5,13 @@ import com.simpaylog.generatorapi.dto.analysis.HourlyTransaction;
 import com.simpaylog.generatorapi.dto.analysis.PeriodTransaction;
 import com.simpaylog.generatorapi.dto.analysis.TimeHeatmapCell;
 import com.simpaylog.generatorapi.dto.chart.ChartIncomeCountDto;
+import com.simpaylog.generatorapi.dto.request.TransactionHistoryRequest;
 import com.simpaylog.generatorapi.dto.response.CommonChart;
 import com.simpaylog.generatorapi.dto.response.Response;
 import com.simpaylog.generatorapi.service.AnalysisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -158,5 +156,10 @@ public class AnalysisController {
             @RequestParam(required = false) Integer userId
     ) {
         return Response.success(HttpStatus.OK.value(), analysisService.searchIncomeExpense(sessionId, durationStart, durationEnd, userId));
+    }
+
+    @PostMapping("/transaction-history")
+    public Response<TransactionHistoryResponseDto> getUserCnt(@RequestBody TransactionHistoryRequest request) {
+        return Response.success(HttpStatus.OK.value(), analysisService.getTransactionHistory(request));
     }
 }

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/controller/AnalysisController.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/controller/AnalysisController.java
@@ -159,7 +159,7 @@ public class AnalysisController {
     }
 
     @PostMapping("/transaction-history")
-    public Response<TransactionHistoryResponseDto> getUserCnt(@RequestBody TransactionHistoryRequest request) {
+    public Response<TransactionHistoryResponseDto> getTransactionHistory(@RequestBody TransactionHistoryRequest request) {
         return Response.success(HttpStatus.OK.value(), analysisService.getTransactionHistory(request));
     }
 }

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/controller/UserController.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/controller/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/dto/analysis/TransactionHistoryDataDto.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/dto/analysis/TransactionHistoryDataDto.java
@@ -1,0 +1,12 @@
+package com.simpaylog.generatorapi.dto.analysis;
+
+import java.math.BigDecimal;
+
+public record TransactionHistoryDataDto(
+        String timestamp,
+        String category,
+        String description,
+        BigDecimal amount,
+        String transactionType
+) {
+}

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/dto/analysis/TransactionHistoryResponseDto.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/dto/analysis/TransactionHistoryResponseDto.java
@@ -1,0 +1,9 @@
+package com.simpaylog.generatorapi.dto.analysis;
+
+import java.util.List;
+
+public record TransactionHistoryResponseDto(
+        List<TransactionHistoryDataDto> transactions,
+        List<String> nextSearchAfter
+) {
+}

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/dto/request/TransactionHistoryRequest.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/dto/request/TransactionHistoryRequest.java
@@ -1,0 +1,13 @@
+package com.simpaylog.generatorapi.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record TransactionHistoryRequest(
+        String sessionId,
+        LocalDate durationStart,
+        LocalDate durationEnd,
+        Integer userId,
+        List<String> searchAfter
+) {
+}

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/service/AnalysisService.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/service/AnalysisService.java
@@ -5,6 +5,7 @@ import com.simpaylog.generatorapi.dto.analysis.*;
 import com.simpaylog.generatorapi.dto.chart.AgeGroupIncomeExpenseAverageDto;
 import com.simpaylog.generatorapi.dto.chart.ChartIncomeCountDto;
 import com.simpaylog.generatorapi.dto.chart.ChartIncomeIncomeExpenseDto;
+import com.simpaylog.generatorapi.dto.request.TransactionHistoryRequest;
 import com.simpaylog.generatorapi.dto.response.CommonChart;
 import com.simpaylog.generatorapi.exception.ApiException;
 import com.simpaylog.generatorapi.exception.ErrorCode;
@@ -12,6 +13,7 @@ import com.simpaylog.generatorapi.repository.Elasticsearch.TransactionAggregatio
 import com.simpaylog.generatorapi.utils.DateValidator;
 import com.simpaylog.generatorcore.dto.analyze.MinMaxDayDto;
 import com.simpaylog.generatorcore.dto.analyze.UserAgeInfo;
+import com.simpaylog.generatorcore.dto.response.UserCntResponse;
 import com.simpaylog.generatorcore.enums.PreferenceType;
 import com.simpaylog.generatorcore.exception.CoreException;
 import com.simpaylog.generatorcore.repository.UserRepository;
@@ -214,6 +216,15 @@ public class AnalysisService {
     public IncomeExpenseDto searchIncomeExpense(String sessionId, String durationStart, String durationEnd, Integer userId) {
         try {
             return transactionAggregationRepository.saerchIncomeExpense(sessionId, durationStart, durationEnd, userId);
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new ApiException(ErrorCode.ELASTICSEARCH_CONNECTION_ERROR);
+        }
+    }
+
+    public TransactionHistoryResponseDto getTransactionHistory(TransactionHistoryRequest request) {
+        try {
+            return transactionAggregationRepository.getTransactionHistory(request);
         } catch (IOException e) {
             log.error(e.getMessage());
             throw new ApiException(ErrorCode.ELASTICSEARCH_CONNECTION_ERROR);


### PR DESCRIPTION
거인 거래 내역 조회 API 개발

## 변경점
1. AnalysisController에 getTransactionHistory메소드 추가
2. AnalysisService에 getTransactionHistory 메소드 추가
3. TransactionHistoryDataDto, TransactionHistoryResponseDto, TransactionHistoryRequest 추가
4. TransactionAggregationRepository에 getTransactionHistory 메소드 추가
 
## 체크리스트
- [x] 통합테스트 완료

## 관련 이슈
- #54