### PR TITLE
[BE] 집계데이터 다운 카테고리별 소비 비율 로직 추가 및 마스킹 재조정

### DIFF
--- a/generator-api/src/main/java/com/simpaylog/generatorapi/dto/document/AggregatedTransactionDocument.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/dto/document/AggregatedTransactionDocument.java
@@ -12,5 +12,14 @@ public record AggregatedTransactionDocument(
         Double foodRatio,
         Double transportRatio,
         Double leisureRatio,
-        Double incomeVsSpending
+        Double incomeVsSpending,
+        Double groceriesNonAlcoholicBeveragesRatio,
+        Double alcoholicBeveragesTobaccoRatio,
+        Double clothingFootwearRatio,
+        Double housingUtilitiesFuelRatio,
+        Double householdGoodsServicesRatio,
+        Double healthRatio,
+        Double communicationRatio,
+        Double educationRatio,
+        Double otherGoodsServicesRatio
 ) { }

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/repository/Elasticsearch/TransactionAggregationRepository.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/repository/Elasticsearch/TransactionAggregationRepository.java
@@ -5,6 +5,7 @@ import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.aggregations.CalendarInterval;
+import co.elastic.clients.elasticsearch._types.aggregations.LongTermsBucket;
 import co.elastic.clients.elasticsearch._types.aggregations.MaxAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.MinAggregate;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
@@ -738,7 +739,10 @@ public class TransactionAggregationRepository {
                             )
                     )
                     .aggregations("by_user", a -> a
-                            .terms(t -> t.field("userId").size(10000))
+                            .terms(t -> t
+                                    .field("userId")
+                                    .size(10000)
+                            )
                             .aggregations("by_month", b -> b
                                     .dateHistogram(d -> d
                                             .field("timestamp")
@@ -757,25 +761,52 @@ public class TransactionAggregationRepository {
                                     )
                                     // top3 카테고리
                                     .aggregations("top3Categories", aa -> aa
-                                            .terms(t -> t.field("category").size(3))
+                                            .terms(t2 -> t2.field("category").size(3))
                                     )
-                                    // food, transport, leisure 비율
-                                    .aggregations("foodRatio", r -> r
-                                            .filter(f -> f.term(t -> t.field("category").value("food")))
+                                    // 카테고리 비율 (전체)
+                                    .aggregations("foodAccommodationRatio", r -> r
+                                            .filter(f -> f.term(t2 -> t2.field("category").value("foodAccommodation")))
                                     )
-                                    .aggregations("transportRatio", r -> r
-                                            .filter(f -> f.term(t -> t.field("category").value("transport")))
+                                    .aggregations("transportationRatio", r -> r
+                                            .filter(f -> f.term(t2 -> t2.field("category").value("transportation")))
                                     )
-                                    .aggregations("leisureRatio", r -> r
-                                            .filter(f -> f.term(t -> t.field("category").value("leisure")))
+                                    .aggregations("recreationCultureRatio", r -> r
+                                            .filter(f -> f.term(t2 -> t2.field("category").value("recreationCulture")))
+                                    )
+                                    .aggregations("groceriesNonAlcoholicBeveragesRatio", r -> r
+                                            .filter(f -> f.term(t2 -> t2.field("category").value("groceriesNonAlcoholicBeverages")))
+                                    )
+                                    .aggregations("alcoholicBeveragesTobaccoRatio", r -> r
+                                            .filter(f -> f.term(t2 -> t2.field("category").value("alcoholicBeveragesTobacco")))
+                                    )
+                                    .aggregations("clothingFootwearRatio", r -> r
+                                            .filter(f -> f.term(t2 -> t2.field("category").value("clothingFootwear")))
+                                    )
+                                    .aggregations("housingUtilitiesFuelRatio", r -> r
+                                            .filter(f -> f.term(t2 -> t2.field("category").value("housingUtilitiesFuel")))
+                                    )
+                                    .aggregations("householdGoodsServicesRatio", r -> r
+                                            .filter(f -> f.term(t2 -> t2.field("category").value("householdGoodsServices")))
+                                    )
+                                    .aggregations("healthRatio", r -> r
+                                            .filter(f -> f.term(t2 -> t2.field("category").value("health")))
+                                    )
+                                    .aggregations("communicationRatio", r -> r
+                                            .filter(f -> f.term(t2 -> t2.field("category").value("communication")))
+                                    )
+                                    .aggregations("educationRatio", r -> r
+                                            .filter(f -> f.term(t2 -> t2.field("category").value("education")))
+                                    )
+                                    .aggregations("otherGoodsServicesRatio", r -> r
+                                            .filter(f -> f.term(t2 -> t2.field("category").value("otherGoodsServices")))
                                     )
                                     // income vs spending
                                     .aggregations("withdrawTotal", a2 -> a2
-                                            .filter(f -> f.term(t -> t.field("transactionType").value("WITHDRAW")))
+                                            .filter(f -> f.term(t2 -> t2.field("transactionType").value("WITHDRAW")))
                                             .aggregations("sum", s -> s.sum(ss -> ss.field("amount")))
                                     )
                                     .aggregations("depositTotal", a2 -> a2
-                                            .filter(f -> f.term(t -> t.field("transactionType").value("DEPOSIT")))
+                                            .filter(f -> f.term(t2 -> t2.field("transactionType").value("DEPOSIT")))
                                             .aggregations("sum", s -> s.sum(ss -> ss.field("amount")))
                                     )
                             )
@@ -784,8 +815,15 @@ public class TransactionAggregationRepository {
 
             SearchResponse<Void> response = elasticsearchClient.search(searchRequest, Void.class);
 
-            // 결과 파싱
-            response.aggregations().get("by_user").lterms().buckets().array().forEach(userBucket -> {
+            // aggregation 결과 가져오기
+            var userBucketsArray = response.aggregations().get("by_user").lterms().buckets().array();
+            // List로 변환
+            List<co.elastic.clients.elasticsearch._types.aggregations.LongTermsBucket> userBucketsList = new ArrayList<>(userBucketsArray);
+            // Java 단에서 userId 오름차순 정렬
+            userBucketsList.sort(Comparator.comparingLong(LongTermsBucket::key)); // Long key 기준
+
+            // 정렬된 리스트로 처리
+            userBucketsList.forEach(userBucket -> {
                 Long userId = userBucket.key();
                 String userIdStr = userId.toString();
 
@@ -805,9 +843,20 @@ public class TransactionAggregationRepository {
                             .stream().map(b -> b.key().stringValue()).toList();
 
                     double docCount = monthBucket.docCount();
-                    double foodRatio = monthBucket.aggregations().get("foodRatio").filter().docCount() / docCount;
-                    double transportRatio = monthBucket.aggregations().get("transportRatio").filter().docCount() / docCount;
-                    double leisureRatio = monthBucket.aggregations().get("leisureRatio").filter().docCount() / docCount;
+
+                    // 비율 계산
+                    double foodAccommodationRatio = monthBucket.aggregations().get("foodAccommodationRatio").filter().docCount() / docCount;
+                    double transportationRatio = monthBucket.aggregations().get("transportationRatio").filter().docCount() / docCount;
+                    double recreationCultureRatio = monthBucket.aggregations().get("recreationCultureRatio").filter().docCount() / docCount;
+                    double groceriesNonAlcoholicBeveragesRatio = monthBucket.aggregations().get("groceriesNonAlcoholicBeveragesRatio").filter().docCount() / docCount;
+                    double alcoholicBeveragesTobaccoRatio = monthBucket.aggregations().get("alcoholicBeveragesTobaccoRatio").filter().docCount() / docCount;
+                    double clothingFootwearRatio = monthBucket.aggregations().get("clothingFootwearRatio").filter().docCount() / docCount;
+                    double housingUtilitiesFuelRatio = monthBucket.aggregations().get("housingUtilitiesFuelRatio").filter().docCount() / docCount;
+                    double householdGoodsServicesRatio = monthBucket.aggregations().get("householdGoodsServicesRatio").filter().docCount() / docCount;
+                    double healthRatio = monthBucket.aggregations().get("healthRatio").filter().docCount() / docCount;
+                    double communicationRatio = monthBucket.aggregations().get("communicationRatio").filter().docCount() / docCount;
+                    double educationRatio = monthBucket.aggregations().get("educationRatio").filter().docCount() / docCount;
+                    double otherGoodsServicesRatio = monthBucket.aggregations().get("otherGoodsServicesRatio").filter().docCount() / docCount;
 
                     double withdrawSum = monthBucket.aggregations()
                             .get("withdrawTotal").filter().aggregations()
@@ -826,18 +875,30 @@ public class TransactionAggregationRepository {
                             BigDecimal.valueOf(totalSpent).setScale(0, RoundingMode.DOWN),
                             BigDecimal.valueOf(avgTxn).setScale(2, RoundingMode.HALF_UP),
                             top3,
-                            foodRatio,
-                            transportRatio,
-                            leisureRatio,
+                            foodAccommodationRatio,
+                            transportationRatio,
+                            recreationCultureRatio,
+                            groceriesNonAlcoholicBeveragesRatio,
+                            alcoholicBeveragesTobaccoRatio,
+                            clothingFootwearRatio,
+                            housingUtilitiesFuelRatio,
+                            householdGoodsServicesRatio,
+                            healthRatio,
+                            communicationRatio,
+                            educationRatio,
+                            otherGoodsServicesRatio,
                             incomeVsSpending
                     );
 
                     consumer.accept(dto);
                 });
             });
+
         } catch (Exception e) {
             log.error("집계 데이터 조회 중 오류: {}", e.getMessage());
             throw new CoreException("Elasticsearch 집계 조회 실패");
         }
     }
+
+
 }

--- a/generator-api/src/main/java/com/simpaylog/generatorapi/utils/FileExporter.java
+++ b/generator-api/src/main/java/com/simpaylog/generatorapi/utils/FileExporter.java
@@ -185,11 +185,11 @@ public class FileExporter {
         return switch (fieldName) {
             case "transactionId" -> {
                 String transactionIdStr = "TX-" + t.transactionId();
-                yield isMasked ? maskMiddle(transactionIdStr, 4, 4) : transactionIdStr;
+                yield isMasked ? masking(transactionIdStr, 4, 4) : transactionIdStr;
             }
             case "userId" -> {
                 String userIdStr = "U-" + t.userId();
-                yield isMasked ? maskMiddle(userIdStr, 2, 2) : userIdStr;
+                yield isMasked ? masking(userIdStr, 2, 2) : userIdStr;
             }
             case "timestamp" -> t.timestamp().format(CSV_DATE_FORMATTER);
             case "transactionType" -> t.transactionType().name();
@@ -217,16 +217,27 @@ public class FileExporter {
             case "foodRatio" -> String.format("%.3f", t.foodRatio());
             case "transportRatio" -> String.format("%.3f", t.transportRatio());
             case "leisureRatio" -> String.format("%.3f", t.leisureRatio());
+            case "groceriesNonAlcoholicBeveragesRatio" -> String.format("%.3f", t.groceriesNonAlcoholicBeveragesRatio());
+            case "alcoholicBeveragesTobaccoRatio" -> String.format("%.3f", t.alcoholicBeveragesTobaccoRatio());
+            case "clothingFootwearRatio" -> String.format("%.3f", t.clothingFootwearRatio());
+            case "housingUtilitiesFuelRatio" -> String.format("%.3f", t.housingUtilitiesFuelRatio());
+            case "householdGoodsServicesRatio" -> String.format("%.3f", t.householdGoodsServicesRatio());
+            case "healthRatio" -> String.format("%.3f", t.healthRatio());
+            case "communicationRatio" -> String.format("%.3f", t.communicationRatio());
+            case "educationRatio" -> String.format("%.3f", t.educationRatio());
+            case "otherGoodsServicesRatio" -> String.format("%.3f", t.otherGoodsServicesRatio());
             case "incomeVsSpending" -> String.format("%.3f", t.incomeVsSpending());
             default -> "";
         };
     }
 
     //데이터 마스킹 메서드
-    private String maskMiddle(String id, int prefixLen, int suffixLen) {
+    private String masking(String id, int prefixLen, int suffixLen) {
         if (id == null || id.isEmpty()) return id;
 
         int length = id.length();
+        if(length == 3) suffixLen = 0;
+        else if(length == 4) suffixLen = 1;
         int maskLen = length - prefixLen - suffixLen;
 
         // 최소 1글자는 마스킹

--- a/generator-core/src/main/java/com/simpaylog/generatorcore/enums/export/TransactionCsvExportHeader.java
+++ b/generator-core/src/main/java/com/simpaylog/generatorcore/enums/export/TransactionCsvExportHeader.java
@@ -22,15 +22,23 @@ public enum TransactionCsvExportHeader {
     AMOUNT("amount", "amount", "금액"),
 
     // 집계 컬럼 예시
+    PERIOD("period", "period", "집계 기준 기간(년-월)"),
     TOTAL_SPENT("totalSpent", "total_spent", "총 지출액"),
     AVG_TRANSACTION("avgTxn", "avg_transaction", "평균 거래액"),
-    PERIOD("period", "period", "집계 기준 기간(년-월)"),
     INCOME_VS_SPENDING("incomeVsSpending", "income_vs_spending", "소득 대비 지출 비율(수입이 전체 거래에서 차지하는 비율)"),
     TOP_3_CATEGORIES("top3Categories", "top_3_categories", "최빈 카테고리 3개"),
     FOOD_RATIO("foodRatio", "food_ratio", "음식 카테고리 거래 비율"),
     TRANSPORT_RATIO("transportRatio", "transport_ratio", "교통 카테고리 거래 비율"),
-    LEISURE_RATIO("leisureRatio", "leisure_ratio", "레저 카테고리 거래 비율");
-//    AGG_USER_ID("aggUserId", "user_id", "레저 카테고리 거래 비율");
+    LEISURE_RATIO("leisureRatio", "leisure_ratio", "레저 카테고리 거래 비율"),
+    GROCERIES_NON_ALCOHOLIC_BEVERAGES_RATIO("groceriesNonAlcoholicBeveragesRatio", "groceries_non_alcoholic_beverages_ratio", "식료품/비알콜 음료 거래 비율"),
+    ALCOHOLIC_BEVERAGES_TOBACCO_RATIO("alcoholicBeveragesTobaccoRatio", "alcoholic_beverages_tobacco_ratio", "주류/담배 거래 비율"),
+    CLOTHING_FOOTWEAR_RATIO("clothingFootwearRatio", "clothing_footwear_ratio", "의류/신발 거래 비율"),
+    HOUSING_UTILITIES_FUEL_RATIO("housingUtilitiesFuelRatio", "housing_utilities_fuel_ratio", "주거/공과금 거래 비율"),
+    HOUSEHOLD_GOODS_SERVICES_RATIO("householdGoodsServicesRatio", "household_goods_services_ratio", "가정용품/가사 서비스 거래 비율"),
+    HEALTH_RATIO("healthRatio", "health_ratio", "건강 거래 비율"),
+    COMMUNICATION_RATIO("communicationRatio", "communication_ratio", "통신 거래 비율"),
+    EDUCATION_RATIO("educationRatio", "education_ratio", "교육 거래 비율"),
+    OTHER_GOODS_SERVICES_RATIO("otherGoodsServicesRatio", "other_goods_services_ratio", "기타 상품/서비스 거래 비율");
 
     private final String fieldName; // TransactionLogDocument 또는 집계 DTO 필드명
     private final String displayName;


### PR DESCRIPTION
## 1. PR내용
집계데이터 다운의 카테고리별 소비 비율 로직 추가 및 id의 prefix가 마스킹되던 마스킹 로직 재조정

## 2. 구현 내용
    - 집계데이터 다운의 카테고리별 소비 비율 로직 추가
    - id의 prefix가 마스킹되던 마스킹 로직 재조정
